### PR TITLE
fix: add missing norwegian translations

### DIFF
--- a/no/auth.json
+++ b/no/auth.json
@@ -25,6 +25,16 @@
       "country_input_error_invalid": "Et gyldig land er påkrevd",
       "choose_another_method_link": "Velg en annen metode"
     },
+    "mfa_email_page": {
+      "page_title": "Skriv inn e-post | ${business_name}",
+      "heading": "Autentiser via e-post",
+      "description": "Legg til en e-postadresse for å motta koder på e-post",
+      "continue_button": "Fortsett",
+      "email_input_label": "E-post",
+      "email_input_error_required": "E-post må fylles ut",
+      "email_input_error_invalid": "E-postadressen er ugyldig",
+      "email_input_error_email_in_use": "E-postadressen er allerede i bruk"
+    },
     "auth_error_page": {
       "page_title": "Autentiseringsfeil",
       "heading": "Autentiseringsfeil"
@@ -270,6 +280,35 @@
       "email_subject": "Bekreftelseskode for e-post",
       "email_greeting": "Hei der,",
       "email_disclaimer": "Du mottok denne e-posten fordi du ba om en bekreftelseskode fra ${business_name}"
+    },
+    "general_errors": {
+      "account_not_found": "Fant ikke brukerkonto.",
+      "action_allowed_only_once": "Denne handlingen kan bare gjøres én gang.",
+      "no_organization_access": "Beklager, du har ikke tilgang til denne organisasjonen.",
+      "operation_not_permitted": "Handlingen kunne ikke fullføres."
+    },
+    "account_not_found_page": {
+      "page_title": "Fant ikke brukerkonto",
+      "heading": "Vi kan ikke finne brukeren din",
+      "description": "Vi trenger bare noen detaljer til for å kunne ferdigstille kontoen din.",
+      "description_sign_ups_disabled": "Prøv å bruke en annen bruker eller innloggingsmetode",
+      "description_social": "Vil du lage en ny med ${social_provider_name}-brukeren din?",
+      "description_credential": "Vil du opprette en bruker med ${credential}?",
+      "continue_button": "Opprett brukerkonto",
+      "back_button": "Tilbake til innlogging",
+      "sign_in_another_way_separator": "eller",
+      "sign_in_another_way_link": "logg inn på en annen måte"
+    },
+    "phone_number_component": {
+      "phone_input_label": "Telefonnummer",
+      "country_select_label": "Land",
+      "use_email_link": "Motta kode på e-post i stedet",
+      "use_phone_link": "Motta kode på telefonen i stedet",
+      "phone_input_error_sms_limit_reached": "Kan ikke sende kode. SMS-tjenesten er ikke satt opp. Logg inn på en annen måte.",
+      "phone_input_error_invalid_country_code": "Ugyldig landkode. Velg et land i listen.",
+      "phone_input_error_required": "Telefonnummer må være oppgitt.",
+      "phone_input_error_invalid_format": "Oppgi et gyldig telefonnummer uten mellomrom og landkode.",
+      "phone_input_error_no_account_found": "Vi fant ingen bruker med dette telefonnummeret."
     }
   }
 }


### PR DESCRIPTION
# Explain your changes

After mobile authentication was added, some translations were missing. I know the context of the `phone_number_component` texts in the Kinde webpage, but the other texts I added after the validation script noted they were missing. Disclaimer: I have not reviewed the other translations visually, so I cannot be 100% sure they are good microcopy for the context they are used in.

I have no experience as a translator, but I have worked as proofreader for some Norwegian publishers when I was younger.

This PR is fixing, amongst other things, missing translations like:
[
![Screenshot 2024-05-24 at 13-18-08 Eliot](https://github.com/kinde-oss/kinde-translations/assets/5270285/24d5f052-1279-4d33-a962-3edfbe53c5a2)
](url)

# Checklist

- [x ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
