### PR TITLE
fix: Move keys in nl translation

### DIFF
--- a/nl/auth.json
+++ b/nl/auth.json
@@ -229,6 +229,7 @@
       "email_input_error_required": "E-mailadres is verplicht",
       "email_input_error_invalid": "Voer een geldig e-mailadres in",
       "email_input_error_invitation_mismatch": "Het e-mailadres moet overeenkomen met het e-mailadres waarnaar uw uitnodiging is verzonden",
+      "email_input_error_domain_invalid": "We kunnen u niet aanmelden met dit e-maildomein. Probeer een ander e-mailadres."
       "continue_with_email_button": "Maak uw account aan",
       "continue_with_social_provider_button": "Doorgaan met ${social_provider_name}",
       "auth_block_separator": "Of",
@@ -245,7 +246,8 @@
       "disclaimer_dialog_description": "Om door te gaan met inschrijven, moet u onze beleidsregels lezen en accepteren",
       "disclaimer": "Door verder te gaan, gaat u akkoord met ons beleid",
       "disclaimer_terms_of_use_link": "Gebruiksvoorwaarden",
-      "disclaimer_privacy_link": "Privacybeleid"
+      "disclaimer_privacy_link": "Privacybeleid",
+      "kp_usr_is_marketing_opt_in_label": "Ja. Stuur me aanbiedingen."
     },
     "sms_verify_code_page": {
       "page_title": "Meervoudige authenticatie | ${business_name}",
@@ -337,12 +339,6 @@
       "email_or_username_input_error_invalid": "Voer een geldige e-mail of gebruikersnaam in",
       "use_username_link": "Overschakelen naar gebruikersnaam",
       "use_email_or_username_link": "Overschakelen naar gebruikersnaam of e-mail"
-    },
-    "email_input_error_domain_invalid": {
-      "email_input_error_domain_invalid": "We kunnen u niet aanmelden met dit e-maildomein. Probeer een ander e-mailadres."
-    },
-    "kp_usr_is_marketing_opt_in_label": {
-      "kp_usr_is_marketing_opt_in_label": "Ja. Stuur me aanbiedingen."
     }
   }
 }

--- a/nl/auth.json
+++ b/nl/auth.json
@@ -229,7 +229,7 @@
       "email_input_error_required": "E-mailadres is verplicht",
       "email_input_error_invalid": "Voer een geldig e-mailadres in",
       "email_input_error_invitation_mismatch": "Het e-mailadres moet overeenkomen met het e-mailadres waarnaar uw uitnodiging is verzonden",
-      "email_input_error_domain_invalid": "We kunnen u niet aanmelden met dit e-maildomein. Probeer een ander e-mailadres."
+      "email_input_error_domain_invalid": "We kunnen u niet aanmelden met dit e-maildomein. Probeer een ander e-mailadres.",
       "continue_with_email_button": "Maak uw account aan",
       "continue_with_social_provider_button": "Doorgaan met ${social_provider_name}",
       "auth_block_separator": "Of",


### PR DESCRIPTION
# Explain your changes

Looks like these two keys should be under `sign_up_page`.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
