### PR TITLE
fix: german email double period

### DIFF
--- a/de/auth.json
+++ b/de/auth.json
@@ -96,7 +96,7 @@
     },
     "email_address_verification_email": {
       "email_body": "Dieser Code wird in 2 Stunden ablaufen. Wenn Sie glauben, dass Sie diese E-Mail nicht erhalten sollten, können Sie sie getrost ignorieren.",
-      "email_preview": "Bitte verwenden Sie den unten stehenden Code, um Ihre E-Mail-Adresse zu bestätigen und bei ${business_name} fortzufahren.",
+      "email_preview": "Bitte verwenden Sie den unten stehenden Code, um Ihre E-Mail-Adresse zu bestätigen und bei ${business_name} fortzufahren",
       "email_subject": "E-Mail-Verifizierungscode",
       "email_greeting": "Hallo zusammen,",
       "email_disclaimer": "Sie haben diese E-Mail erhalten, weil Sie einen Bestätigungscode von ${business_name} angefordert haben."


### PR DESCRIPTION
# Explain your changes

Removes extra period from end of translaton which was causing a double period to show in the emails.

Source: https://discord.com/channels/1070212618549219328/1301113030905696256/1301113030905696256

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
