### PR TITLE
Typo and spelling fix for german translation

### DIFF
--- a/de/auth.json
+++ b/de/auth.json
@@ -156,7 +156,7 @@
       "email_body": "Hallo zusammen,\r\nBitte verwenden Sie den unten stehenden Code, um Ihre E-Mail-Adresse zu bestätigen und bei ${business_name} fortzufahren. Dieser Code wird in 2 Stunden ablaufen. Wenn Sie glauben, dass Sie diese E-Mail nicht erhalten sollten, können Sie sie getrost ignorieren.",
       "email_preview": "Bitte verwenden Sie den unten stehenden Code, um Ihre E-Mail-Adresse zu bestätigen und bei ${business_name} fortzufahren",
       "email_subject": "E-Mail-Verifizierungscode",
-      "email_disclaimer": "Sie haben diese E-Mail erhalten, weil Sie einen Bestätigungscode von ${business_name} angefordert haben."
+      "email_disclaimer": "Sie haben diese E-Mail erhalten, weil Sie einen Bestätigungscode von ${business_name} angefordert haben"
     },
     "password_setup_page": {
       "page_title": "Passwort festlegen | ${business_name}",

--- a/de/auth.json
+++ b/de/auth.json
@@ -153,7 +153,7 @@
       "didnt_receive_a_code_link": "Code erneut senden"
     },
     "email_address_verification_email": {
-      "email_body": "Hallo zusammen,\r\nBitte verwenden Sie den unten stehenden Code, um Ihre E-Mail-Adresse zu bestätigen und bei ${business_name} fortzufahren. Dieser Code wird in 2 Stunden ablaufen. Wenn Sie glauben, dass Sie diese E-Mail nicht erhalten sollten, können Sie sie getrost ignorieren.",
+      "email_body": "Hallo zusammen,\r\nbitte verwenden Sie den unten stehenden Code, um Ihre E-Mail-Adresse zu bestätigen und bei ${business_name} fortzufahren. Dieser Code wird in 2 Stunden ablaufen. Wenn Sie glauben, dass Sie diese E-Mail nicht erhalten sollten, können Sie sie getrost ignorieren.",
       "email_preview": "Bitte verwenden Sie den unten stehenden Code, um Ihre E-Mail-Adresse zu bestätigen und bei ${business_name} fortzufahren",
       "email_subject": "E-Mail-Verifizierungscode",
       "email_disclaimer": "Sie haben diese E-Mail erhalten, weil Sie einen Bestätigungscode von ${business_name} angefordert haben"


### PR DESCRIPTION
# Explain your changes

Hey there!

This PR fixes a typo and a spelling issue in the german translation of the otp email (`email_address_verification_email`):

The casing for the word after the greeting has to be lowercase (`Hallo zusammen, bitte...` instead of  `Bitte`).

The `email_disclaimer` has an unnecessary trailing dot (in contrast to its english counterpart), which leads to two dots `..` being rendered in the final email sent by kinde:

![image](https://github.com/user-attachments/assets/d4d87f2b-f2e8-4395-b702-e8a746136d97)

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
