### PR TITLE
Fixed a typo in the Flemish translations file

### DIFF
--- a/nl-BE/auth.json
+++ b/nl-BE/auth.json
@@ -292,7 +292,7 @@
       "continue_with_social_provider_button": "Doorgaan met ${social_provider_name}",
       "auth_block_separator": "Of",
       "continue_with_enterprise_provider_button": "Doorgaan met ${enterprise_provider_name}",
-      "already_have_an_account_description": "Heet u al een account?",
+      "already_have_an_account_description": "Heeft u al een account?",
       "already_have_an_account_link": "Inloggen",
       "auth_form_error_org_not_accepting_registrations": "De door u geselecteerde organisatie accepteert geen aanmeldingen",
       "auth_form_error_no_auth_methods_enabled": "Sorry, we zien momenteel geen manier om u te verifiëren",


### PR DESCRIPTION
# Explain your changes

The Flemish translations (nl-BE) contained a typo, changed "Heet" to "Hee**f**t" in the sentence "Heet u al een account?".

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
