### PR TITLE
Change wording for English subscription success message

### DIFF
--- a/en/auth.json
+++ b/en/auth.json
@@ -532,7 +532,7 @@
     "subscription_success_page": {
       "translate_context": "Page shown after a successful subscription",
       "page_title": "Subscription success | ${business_name}",
-      "heading": "Your payment details are in the vault!",
+      "heading": "Your subscription to the ${plan_name} plan is active!",
       "description": "Take your business to the next level with your new plan",
       "continue_button": "Continue"
     },


### PR DESCRIPTION
# Explain your changes

When a user subscribes to a plan, the message currently being displayed assumes that a payment method was required (and entered) by the end-user.

This change changes the wording of the success message to not refer to a payment method, but instead reference the plan the user is subscribing to.

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
