### PR TITLE
fix Norwegian translation of didnt_receive_a_code_description

### DIFF
--- a/no/auth.json
+++ b/no/auth.json
@@ -321,7 +321,7 @@
       "code_input_error_resend_requested_too_soon": "Kan ikke sende en annen kode ennå. Prøv igjen senere",
       "continue_button": "Fortsett",
       "didnt_receive_a_code_link": "Send kode på nytt",
-      "didnt_receive_a_code_description": "Mottok ikke en kode?",
+      "didnt_receive_a_code_description": "Ikke mottatt kode?",
       "choose_another_method_link": "Velg en annen metode",
       "translate_context": "Page to confirm the email code sent during sign-in"
     },


### PR DESCRIPTION
# Explain your changes

- Fixed the Norwegian translation of `didnt_receive_a_code_description` as "Mottok ikke en kode?" is not correct grammar. It would also work to say "Har du ikke mottatt (en) kode?", but "Ikke mottatt kode?" is shorter and preferable, I think.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
