### PR TITLE
feat(auth): add passkey sign-in and setup page translations

### DIFF
--- a/cs/auth.json
+++ b/cs/auth.json
@@ -85,7 +85,8 @@
       "email_or_username_input_error_invalid": "Zadejte platný e-mail nebo uživatelské jméno",
       "use_username_link": "Přepnutí na uživatelské jméno",
       "use_email_or_username_link": "Přepnutí na uživatelské jméno nebo e-mail",
-      "please_select_an_option": "Vyberte prosím jednu z možností"
+      "please_select_an_option": "Vyberte prosím jednu z možností",
+      "sign_in_with_passkey_button": "Přihlásit se pomocí přístupového klíče"
     },
     "sign_up_page": {
       "page_title": "Registrace | ${business_name}",
@@ -568,6 +569,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Bezplatná zkušební verze pro"
+    },
+    "passkey_setup_page": {
+      "heading": "Nastavit přístupový kód",
+      "description": "Při příštím přihlášení použijte biometrické údaje svého zařízení nebo bezpečnostní klíč.",
+      "continue_button": "Pokračovat",
+      "use_passkey_button": "Použít přístupový kód",
+      "skip_passkey_link": "Teď ne"
     }
   }
 }

--- a/da/auth.json
+++ b/da/auth.json
@@ -88,7 +88,8 @@
       "use_username_link": "Skift til brugernavn",
       "use_email_or_username_link": "Skift til brugernavn eller e-mail",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "Vælg en mulighed"
+      "please_select_an_option": "Vælg en mulighed",
+      "sign_in_with_passkey_button": "Log ind med adgangskode"
     },
     "sign_up_page": {
       "page_title": "Log på | ${business_name}",
@@ -579,6 +580,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Gratis prøveperiode for"
+    },
+    "passkey_setup_page": {
+      "heading": "Opret adgangskode",
+      "description": "Brug din enheds biometriske funktioner eller sikkerhedsnøgle til at logge hurtigt ind næste gang.",
+      "continue_button": "Fortsæt",
+      "use_passkey_button": "Brug adgangskode",
+      "skip_passkey_link": "Ikke nu"
     }
   }
 }

--- a/de/auth.json
+++ b/de/auth.json
@@ -105,7 +105,8 @@
       "use_username_link": "Zu Benutzername wechseln",
       "use_email_or_username_link": "Zu Benutzername oder E-Mail wechseln",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "Bitte wählen Sie eine Option aus"
+      "please_select_an_option": "Bitte wählen Sie eine Option aus",
+      "sign_in_with_passkey_button": "Mit Passkey anmelden"
     },
     "sign_up_confirm_code_page": {
       "description_continue_sign_up": "Geben Sie den Code ein, den wir gerade an ${email_address} gesendet haben, um fortzufahren.",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Kostenlose Testversion für"
+    },
+    "passkey_setup_page": {
+      "heading": "Passwort einrichten",
+      "description": "Verwenden Sie beim nächsten Mal die biometrischen Funktionen Ihres Geräts oder Ihren Sicherheitsschlüssel, um sich schnell anzumelden.",
+      "continue_button": "Weiter",
+      "use_passkey_button": "Passwort verwenden",
+      "skip_passkey_link": "Nicht jetzt"
     }
   }
 }

--- a/el/auth.json
+++ b/el/auth.json
@@ -96,7 +96,8 @@
       "email_or_username_input_error_invalid": "Εισάγετε έγκυρο email ή όνομα χρήστη",
       "use_username_link": "Μετάβαση σε όνομα χρήστη",
       "use_email_or_username_link": "Μετάβαση σε όνομα χρήστη ή email",
-      "please_select_an_option": "Παρακαλώ επιλέξτε μια επιλογή"
+      "please_select_an_option": "Παρακαλώ επιλέξτε μια επιλογή",
+      "sign_in_with_passkey_button": "Σύνδεση με κωδικό πρόσβασης"
     },
     "sign_up_page": {
       "page_title": "Εγγραφή | ${business_name}",
@@ -531,6 +532,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Δωρεάν δοκιμή για"
+    },
+    "passkey_setup_page": {
+      "heading": "Ρύθμιση κωδικού πρόσβασης",
+      "description": "Χρησιμοποιήστε τα βιομετρικά στοιχεία της συσκευής σας ή το κλειδί ασφαλείας για να συνδεθείτε γρήγορα την επόμενη φορά.",
+      "continue_button": "Συνέχεια",
+      "use_passkey_button": "Χρήση κωδικού πρόσβασης",
+      "skip_passkey_link": "Όχι τώρα"
     }
   }
 }

--- a/en-GB/auth.json
+++ b/en-GB/auth.json
@@ -85,7 +85,8 @@
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
       "phone_input_label": "Phone number",
       "country_select_label": "Country",
-      "please_select_an_option": "Please select an option"
+      "please_select_an_option": "Please select an option",
+      "sign_in_with_passkey_button": "Sign in with passkey"
     },
     "sign_up_page": {
       "page_title": "Sign up | ${business_name}",
@@ -570,6 +571,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Free trial for"
+    },
+    "passkey_setup_page": {
+      "heading": "Set up passkey",
+      "description": "Use your device biometrics or security key to sign in quickly next time.",
+      "continue_button": "Continue",
+      "use_passkey_button": "Use passkey",
+      "skip_passkey_link": "Not now"
     }
   }
 }

--- a/en-US/auth.json
+++ b/en-US/auth.json
@@ -85,7 +85,8 @@
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
       "phone_input_label": "Phone number",
       "country_select_label": "Country",
-      "please_select_an_option": "Please select an option"
+      "please_select_an_option": "Please select an option",
+      "sign_in_with_passkey_button": "Sign in with passkey"
     },
     "sign_up_page": {
       "page_title": "Sign up | ${business_name}",
@@ -568,6 +569,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Free trial for"
+    },
+    "passkey_setup_page": {
+      "heading": "Set up passkey",
+      "description": "Use your device biometrics or security key to sign in quickly next time.",
+      "continue_button": "Continue",
+      "use_passkey_button": "Use passkey",
+      "skip_passkey_link": "Not now"
     }
   }
 }

--- a/en/auth.json
+++ b/en/auth.json
@@ -102,7 +102,8 @@
       "email_or_username_input_error_invalid": "Enter a valid email or username",
       "use_username_link": "Switch to username",
       "use_email_or_username_link": "Switch to username or email",
-      "please_select_an_option": "Please select an option"
+      "please_select_an_option": "Please select an option",
+      "sign_in_with_passkey_button": "Sign in with passkey"
     },
     "sign_up_page": {
       "translate_context": "Page for creating a new Kinde account",
@@ -567,6 +568,13 @@
       "frequency_monthly": "month",
       "frequency_annual": "year",
       "subscribe_button": "Subscribe and pay now"
+    },
+    "passkey_setup_page": {
+      "heading": "Set up passkey",
+      "description": "Use your device biometrics or security key to sign in quickly next time.",
+      "continue_button": "Continue",
+      "use_passkey_button": "Use passkey",
+      "skip_passkey_link": "Not now"
     }
   }
 }

--- a/es/auth.json
+++ b/es/auth.json
@@ -289,7 +289,8 @@
       "email_or_username_input_error_invalid": "Introduzca un correo electrónico o nombre de usuario válido",
       "use_username_link": "Cambiar a nombre de usuario",
       "use_email_or_username_link": "Cambiar a nombre de usuario o correo electrónico",
-      "please_select_an_option": "Seleccione una opción"
+      "please_select_an_option": "Seleccione una opción",
+      "sign_in_with_passkey_button": "Iniciar sesión con clave de acceso"
     },
     "sign_up_confirm_code_page": {
       "description_continue_sign_up": "Para continuar, ingrese el código que acabamos de enviar a ${email_address}",
@@ -579,6 +580,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Prueba gratuita de"
+    },
+    "passkey_setup_page": {
+      "heading": "Configurar clave de acceso",
+      "description": "La próxima vez, utiliza los datos biométricos de tu dispositivo o una llave de seguridad para iniciar sesión rápidamente.",
+      "continue_button": "Continuar",
+      "use_passkey_button": "Usar clave de acceso",
+      "skip_passkey_link": "Ahora no"
     }
   }
 }

--- a/et/auth.json
+++ b/et/auth.json
@@ -102,7 +102,8 @@
       "use_username_link": "Kasuta kasutajanime",
       "use_email_or_username_link": "Kasuta e-posti või kasutajanime",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "Palun valige üks variant"
+      "please_select_an_option": "Palun valige üks variant",
+      "sign_in_with_passkey_button": "Logi sisse paroolivõtmega"
     },
     "sign_up_page": {
       "page_title": "Registreeru | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Tasuta prooviversioon"
+    },
+    "passkey_setup_page": {
+      "heading": "Salasõna seadistamine",
+      "description": "Kasuta järgmisel korral sisselogimiseks oma seadme biomeetrilisi andmeid või turvakoodi.",
+      "continue_button": "Jätka",
+      "use_passkey_button": "Kasuta salasõna",
+      "skip_passkey_link": "Mitte praegu"
     }
   }
 }

--- a/fr/auth.json
+++ b/fr/auth.json
@@ -86,7 +86,8 @@
       "use_username_link": "Utiliser un nom d'utilisateur",
       "use_email_or_username_link": "Utiliser un nom d'utilisateur ou un l'email",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "Veuillez sélectionner une option"
+      "please_select_an_option": "Veuillez sélectionner une option",
+      "sign_in_with_passkey_button": "Se connecter avec une clé d'accès"
     },
     "sign_up_page": {
       "page_title": "Inscription | ${business_name}",
@@ -568,6 +569,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Essai gratuit pour"
+    },
+    "passkey_setup_page": {
+      "heading": "Configurer un mot de passe",
+      "description": "Utilisez les données biométriques de votre appareil ou votre clé de sécurité pour vous connecter rapidement la prochaine fois.",
+      "continue_button": "Continuer",
+      "use_passkey_button": "Utiliser le mot de passe",
+      "skip_passkey_link": "Pas maintenant"
     }
   }
 }

--- a/he/auth.json
+++ b/he/auth.json
@@ -301,7 +301,8 @@
       "email_or_username_input_error_invalid": "הזן כתובת דוא\"ל או שם משתמש חוקיים",
       "use_username_link": "החלף לשם משתמש",
       "use_email_or_username_link": "החלף לשם משתמש או דוא\"ל",
-      "please_select_an_option": "אנא בחר אפשרות"
+      "please_select_an_option": "אנא בחר אפשרות",
+      "sign_in_with_passkey_button": "התחבר באמצעות מפתח גישה"
     },
     "sign_up_confirm_code_page": {
       "description_continue_sign_up": "כדי להמשיך, הזינו את הקוד ששלחנו הרגע ל- ${email_address}",
@@ -579,6 +580,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "ניסיון חינם ל"
+    },
+    "passkey_setup_page": {
+      "heading": "הגדר סיסמה",
+      "description": "השתמש בנתונים הביומטריים של המכשיר או במפתח האבטחה כדי להתחבר במהירות בפעם הבאה.",
+      "continue_button": "המשך",
+      "use_passkey_button": "השתמש במפתח גישה",
+      "skip_passkey_link": "לא עכשיו"
     }
   }
 }

--- a/hu/auth.json
+++ b/hu/auth.json
@@ -85,7 +85,8 @@
       "email_or_username_input_error_invalid": "Adjon meg egy érvényes e-mailt vagy felhasználónevet",
       "use_username_link": "Felhasználónévre váltás",
       "use_email_or_username_link": "Váltás felhasználónévre vagy e-mailre",
-      "please_select_an_option": "Kérjük, válasszon egy lehetőséget"
+      "please_select_an_option": "Kérjük, válasszon egy lehetőséget",
+      "sign_in_with_passkey_button": "Bejelentkezés jelszóval"
     },
     "sign_up_page": {
       "page_title": "Regisztráció | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Ingyenes próba"
+    },
+    "passkey_setup_page": {
+      "heading": "Jelszó beállítása",
+      "description": "Legközelebb a készülék biometrikus adataival vagy biztonsági kulcsával jelentkezzen be gyorsan.",
+      "continue_button": "Tovább",
+      "use_passkey_button": "Jelszó használata",
+      "skip_passkey_link": "Most ne"
     }
   }
 }

--- a/id/auth.json
+++ b/id/auth.json
@@ -73,7 +73,8 @@
       "email_or_username_input_error_invalid": "Masukkan email atau nama pengguna yang valid",
       "use_username_link": "Beralih ke nama pengguna",
       "use_email_or_username_link": "Beralih ke nama pengguna atau email",
-      "please_select_an_option": "Silakan pilih opsi"
+      "please_select_an_option": "Silakan pilih opsi",
+      "sign_in_with_passkey_button": "Masuk dengan passkey"
     },
     "sign_up_page": {
       "page_title": "Mendaftar | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Uji coba gratis untuk"
+    },
+    "passkey_setup_page": {
+      "heading": "Atur kata sandi",
+      "description": "Gunakan fitur biometrik perangkat Anda atau kunci keamanan untuk masuk dengan cepat di lain waktu.",
+      "continue_button": "Lanjutkan",
+      "use_passkey_button": "Gunakan kata sandi",
+      "skip_passkey_link": "Tidak sekarang"
     }
   }
 }

--- a/it/auth.json
+++ b/it/auth.json
@@ -85,7 +85,8 @@
       "use_username_link": "Passa al nome utente",
       "use_email_or_username_link": "Passa al nome utente o email",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "Seleziona un'opzione"
+      "please_select_an_option": "Seleziona un'opzione",
+      "sign_in_with_passkey_button": "Accedi con passkey"
     },
     "sign_up_page": {
       "page_title": "Registrati | ${business_name}",
@@ -569,6 +570,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Prova gratuita per"
+    },
+    "passkey_setup_page": {
+      "heading": "Imposta la password",
+      "description": "La prossima volta, usa i dati biometrici del tuo dispositivo o la chiave di sicurezza per accedere rapidamente.",
+      "continue_button": "Continua",
+      "use_passkey_button": "Usa la chiave di accesso",
+      "skip_passkey_link": "Non adesso"
     }
   }
 }

--- a/ja/auth.json
+++ b/ja/auth.json
@@ -85,7 +85,8 @@
       "use_username_link": "ユーザー名に切り替える",
       "use_email_or_username_link": "メールアドレスまたはユーザー名に切り替える",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "オプションを選択してください"
+      "please_select_an_option": "オプションを選択してください",
+      "sign_in_with_passkey_button": "パスキーでログイン"
     },
     "sign_up_page": {
       "page_title": "サインアップ | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "無料トライアル"
+    },
+    "passkey_setup_page": {
+      "heading": "パスキーを設定する",
+      "description": "次回は、デバイスの生体認証またはセキュリティキーを使って、すばやくサインインしてください。",
+      "continue_button": "続きを読む",
+      "use_passkey_button": "パスキーを使用する",
+      "skip_passkey_link": "今はいい"
     }
   }
 }

--- a/ko/auth.json
+++ b/ko/auth.json
@@ -85,7 +85,8 @@
       "use_username_link": "아이디로 바꾸기",
       "use_email_or_username_link": "아이디나 이메일로 바꾸기",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "옵션을 선택해 주세요"
+      "please_select_an_option": "옵션을 선택해 주세요",
+      "sign_in_with_passkey_button": "패스키로 로그인"
     },
     "sign_up_page": {
       "page_title": "회원가입 | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "무료 체험"
+    },
+    "passkey_setup_page": {
+      "heading": "패스키 설정",
+      "description": "다음 번에는 기기의 생체 인식 기능이나 보안 키를 사용하여 빠르게 로그인하세요.",
+      "continue_button": "계속",
+      "use_passkey_button": "패스키 사용",
+      "skip_passkey_link": "지금은 아니에요"
     }
   }
 }

--- a/lt/auth.json
+++ b/lt/auth.json
@@ -102,7 +102,8 @@
       "email_or_username_input_error_invalid": "Įveskite galiojantį el. pašto adresą arba vartotojo vardą",
       "use_username_link": "Naudoti vartotojo vardą",
       "use_email_or_username_link": "Naudoti vartotojo vardą arba el. paštą",
-      "please_select_an_option": "Prašome pasirinkti vieną iš variantų"
+      "please_select_an_option": "Prašome pasirinkti vieną iš variantų",
+      "sign_in_with_passkey_button": "Prisijungti su slaptažodžiu"
     },
     "sign_up_page": {
       "translate_context": "Page for creating a new Kinde account",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Nemokama bandomoji versija"
+    },
+    "passkey_setup_page": {
+      "heading": "Nustatyti slaptažodį",
+      "description": "Kitą kartą prisijunkite greitai naudodami savo įrenginio biometrinius duomenis arba saugumo raktą.",
+      "continue_button": "Tęsti",
+      "use_passkey_button": "Naudoti slaptažodį",
+      "skip_passkey_link": "Ne dabar"
     }
   }
 }

--- a/lv/auth.json
+++ b/lv/auth.json
@@ -85,7 +85,8 @@
       "email_or_username_input_error_invalid": "Ievadiet derīgu e-pastu vai lietotājvārdu",
       "use_username_link": "Pāriet uz lietotājvārdu",
       "use_email_or_username_link": "Pārslēgties uz lietotājvārdu vai e-pastu",
-      "please_select_an_option": "Lūdzu, izvēlieties vienu no variantiem"
+      "please_select_an_option": "Lūdzu, izvēlieties vienu no variantiem",
+      "sign_in_with_passkey_button": "Piesakies ar paroli"
     },
     "sign_up_page": {
       "page_title": "Reģistrēties | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Bezmaksas izmēģinājuma versija"
+    },
+    "passkey_setup_page": {
+      "heading": "Iestatīt paroli",
+      "description": "Lai nākamreiz ātri pieteiktos, izmantojiet savas ierīces biometrisko datu vai drošības atslēgu.",
+      "continue_button": "Turpināt",
+      "use_passkey_button": "Izmantot piekļuves kodu",
+      "skip_passkey_link": "Ne tagad"
     }
   }
 }

--- a/nl/auth.json
+++ b/nl/auth.json
@@ -277,7 +277,8 @@
       "use_username_link": "Overschakelen naar gebruikersnaam",
       "use_email_or_username_link": "Overschakelen naar gebruikersnaam of e-mail",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "Selecteer een optie"
+      "please_select_an_option": "Selecteer een optie",
+      "sign_in_with_passkey_button": "Aanmelden met passkey"
     },
     "sign_up_confirm_code_page": {
       "description_continue_sign_up": "Om door te gaan, voert u de code in die we zojuist naar ${email_address} hebben gestuurd.",
@@ -580,6 +581,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Gratis proefperiode voor"
+    },
+    "passkey_setup_page": {
+      "heading": "Toegangscode instellen",
+      "description": "Gebruik de biometrische gegevens van je apparaat of je beveiligingssleutel om de volgende keer snel in te loggen.",
+      "continue_button": "Ga verder",
+      "use_passkey_button": "Gebruik de toegangscode",
+      "skip_passkey_link": "Nu niet"
     }
   }
 }

--- a/pl/auth.json
+++ b/pl/auth.json
@@ -97,7 +97,8 @@
       "email_or_username_input_error_invalid": "Wprowadź prawidłowy adres e-mail lub nazwę użytkownika",
       "use_username_link": "Przełącz na nazwę użytkownika",
       "use_email_or_username_link": "Przełącz na nazwę użytkownika lub e-mail",
-      "please_select_an_option": "Proszę wybrać opcję"
+      "please_select_an_option": "Proszę wybrać opcję",
+      "sign_in_with_passkey_button": "Zaloguj się za pomocą klucza dostępu"
     },
     "sign_up_page": {
       "page_title": "Zarejestruj się | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Bezpłatna wersja próbna"
+    },
+    "passkey_setup_page": {
+      "heading": "Skonfiguruj hasło",
+      "description": "Aby następnym razem zalogować się szybko, użyj danych biometrycznych swojego urządzenia lub klucza bezpieczeństwa.",
+      "continue_button": "Kontynuuj",
+      "use_passkey_button": "Użyj hasła",
+      "skip_passkey_link": "Nie teraz"
     }
   }
 }

--- a/pt-BR/auth.json
+++ b/pt-BR/auth.json
@@ -85,7 +85,8 @@
       "use_username_link": "Trocar para nome de usuário",
       "use_email_or_username_link": "Trocar para nome de usuário ou telefone",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "Selecione uma opção"
+      "please_select_an_option": "Selecione uma opção",
+      "sign_in_with_passkey_button": "Faça login com a senha"
     },
     "sign_up_page": {
       "page_title": "Cadastre-se | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Teste gratuito para"
+    },
+    "passkey_setup_page": {
+      "heading": "Configurar senha",
+      "description": "Use os recursos biométricos do seu dispositivo ou uma chave de segurança para fazer login rapidamente na próxima vez.",
+      "continue_button": "Continuar",
+      "use_passkey_button": "Usar senha",
+      "skip_passkey_link": "Agora não"
     }
   }
 }

--- a/pt-PT/auth.json
+++ b/pt-PT/auth.json
@@ -97,7 +97,8 @@
       "email_or_username_input_error_invalid": "Introduzir um e-mail ou nome de utilizador válido",
       "use_username_link": "Mudar para o nome de utilizador",
       "use_email_or_username_link": "Mudar para nome de utilizador ou e-mail",
-      "please_select_an_option": "Selecione uma opção"
+      "please_select_an_option": "Selecione uma opção",
+      "sign_in_with_passkey_button": "Iniciar sessão com chave de acesso"
     },
     "sign_up_page": {
       "page_title": "Registe-se | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Teste gratuito para"
+    },
+    "passkey_setup_page": {
+      "heading": "Configurar a senha",
+      "description": "Da próxima vez, utilize os dados biométricos do seu dispositivo ou a chave de segurança para iniciar sessão rapidamente.",
+      "continue_button": "Continuar",
+      "use_passkey_button": "Utilizar a chave de acesso",
+      "skip_passkey_link": "Agora não"
     }
   }
 }

--- a/ro/auth.json
+++ b/ro/auth.json
@@ -97,7 +97,8 @@
       "email_or_username_input_error_invalid": "Introduceți un e-mail sau un nume de utilizator valid",
       "use_username_link": "Trecerea la numele de utilizator",
       "use_email_or_username_link": "Treceți la nume de utilizator sau e-mail",
-      "please_select_an_option": "Vă rugăm să selectați o opțiune"
+      "please_select_an_option": "Vă rugăm să selectați o opțiune",
+      "sign_in_with_passkey_button": "Conectați-vă cu cheia de acces"
     },
     "sign_up_page": {
       "page_title": "Autentificare | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Încercare gratuită pentru"
+    },
+    "passkey_setup_page": {
+      "heading": "Configurare parolă",
+      "description": "Folosește datele biometrice ale dispozitivului sau cheia de securitate pentru a te autentifica rapid data viitoare.",
+      "continue_button": "Continuă",
+      "use_passkey_button": "Folosiți parola",
+      "skip_passkey_link": "Nu acum"
     }
   }
 }

--- a/ru/auth.json
+++ b/ru/auth.json
@@ -97,7 +97,8 @@
       "email_or_username_input_error_invalid": "Введите действующий адрес электронной почты или имя пользователя",
       "use_username_link": "Переход на имя пользователя",
       "use_email_or_username_link": "Переключение на имя пользователя или электронную почту",
-      "please_select_an_option": "Выберите один из вариантов"
+      "please_select_an_option": "Выберите один из вариантов",
+      "sign_in_with_passkey_button": "Войти с помощью пароля"
     },
     "sign_up_page": {
       "page_title": "Регистрация | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Бесплатная пробная версия для"
+    },
+    "passkey_setup_page": {
+      "heading": "Установить пароль",
+      "description": "Чтобы в следующий раз войти в систему быстрее, воспользуйтесь биометрическими данными устройства или ключом безопасности.",
+      "continue_button": "Продолжить",
+      "use_passkey_button": "Использовать пароль",
+      "skip_passkey_link": "Не сейчас"
     }
   }
 }

--- a/sk/auth.json
+++ b/sk/auth.json
@@ -102,7 +102,8 @@
       "use_username_link": "Prepnúť na používateľské meno",
       "use_email_or_username_link": "Prepnúť na používateľské meno alebo email",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "Vyberte si jednu z možností"
+      "please_select_an_option": "Vyberte si jednu z možností",
+      "sign_in_with_passkey_button": "Prihlásiť sa pomocou prístupového kľúča"
     },
     "sign_up_page": {
       "page_title": "Registrácia | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Bezplatná skúšobná verzia pre"
+    },
+    "passkey_setup_page": {
+      "heading": "Nastaviť prístupový kód",
+      "description": "Pri ďalšom prihlásení použite biometrické údaje svojho zariadenia alebo bezpečnostný kľúč.",
+      "continue_button": "Pokračovať",
+      "use_passkey_button": "Použiť prístupový kód",
+      "skip_passkey_link": "Teraz nie"
     }
   }
 }

--- a/sv/auth.json
+++ b/sv/auth.json
@@ -97,7 +97,8 @@
       "email_or_username_input_error_invalid": "Ange en giltig e-postadress eller ett giltigt användarnamn",
       "use_username_link": "Byt till användarnamn",
       "use_email_or_username_link": "Byt till användarnamn eller e-post",
-      "please_select_an_option": "Välj ett alternativ"
+      "please_select_an_option": "Välj ett alternativ",
+      "sign_in_with_passkey_button": "Logga in med passnyckel"
     },
     "sign_up_page": {
       "page_title": "Registrera | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Gratis provperiod för"
+    },
+    "passkey_setup_page": {
+      "heading": "Ställ in lösenord",
+      "description": "Använd enhetens biometriska funktioner eller säkerhetsnyckel för att logga in snabbt nästa gång.",
+      "continue_button": "Fortsätt",
+      "use_passkey_button": "Använd lösenord",
+      "skip_passkey_link": "Inte nu"
     }
   }
 }

--- a/th/auth.json
+++ b/th/auth.json
@@ -85,7 +85,8 @@
       "use_username_link": "เปลี่ยนเป็นชื่อผู้ใช้",
       "use_email_or_username_link": "เปลี่ยนเป็นชื่อผู้ใช้หรืออีเมล",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "กรุณาเลือกตัวเลือก"
+      "please_select_an_option": "กรุณาเลือกตัวเลือก",
+      "sign_in_with_passkey_button": "ลงชื่อเข้าใช้ด้วยพาสคีย์"
     },
     "sign_up_page": {
       "page_title": "สมัครสมาชิก | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "ทดลองใช้ฟรีสำหรับ"
+    },
+    "passkey_setup_page": {
+      "heading": "ตั้งค่าพาสคีย์",
+      "description": "ใช้ข้อมูลชีวมิติหรือกุญแจความปลอดภัยของอุปกรณ์คุณเพื่อลงชื่อเข้าใช้อย่างรวดเร็วในครั้งต่อไป",
+      "continue_button": "ดำเนินการต่อ",
+      "use_passkey_button": "ใช้พาสคีย์",
+      "skip_passkey_link": "ไม่ตอนนี้"
     }
   }
 }

--- a/tr/auth.json
+++ b/tr/auth.json
@@ -88,7 +88,8 @@
       "email_or_username_input_error_invalid": "Geçerli bir e-posta veya kullanıcı adı girin",
       "use_username_link": "Kullanıcı adına geç",
       "use_email_or_username_link": "Kullanıcı adına veya e-postaya geçme",
-      "please_select_an_option": "Lütfen bir seçenek seçin"
+      "please_select_an_option": "Lütfen bir seçenek seçin",
+      "sign_in_with_passkey_button": "Şifre anahtarıyla giriş yap"
     },
     "sign_up_page": {
       "page_title": "Kaydol | ${business_name}",
@@ -582,6 +583,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Ücretsiz deneme sürümü"
+    },
+    "passkey_setup_page": {
+      "heading": "Şifre oluştur",
+      "description": "Bir dahaki sefere hızlı bir şekilde oturum açmak için cihazınızın biyometrik özelliklerini veya güvenlik anahtarını kullanın.",
+      "continue_button": "Devam et",
+      "use_passkey_button": "Şifreyi kullan",
+      "skip_passkey_link": "Şimdi değil"
     }
   }
 }

--- a/uk/auth.json
+++ b/uk/auth.json
@@ -97,7 +97,8 @@
       "email_or_username_input_error_invalid": "Введіть дійсну електронну пошту або ім'я користувача",
       "use_username_link": "Перейти до імені користувача",
       "use_email_or_username_link": "Переключитися на ім'я користувача або електронну пошту",
-      "please_select_an_option": "Будь ласка, виберіть варіант"
+      "please_select_an_option": "Будь ласка, виберіть варіант",
+      "sign_in_with_passkey_button": "Увійти за допомогою пароля"
     },
     "sign_up_page": {
       "page_title": "Зареєструватися | ${business_name}",
@@ -568,6 +569,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Безкоштовна пробна версія для"
+    },
+    "passkey_setup_page": {
+      "heading": "Налаштувати пароль",
+      "description": "Наступного разу скористайтеся біометричними даними вашого пристрою або ключем безпеки, щоб швидко увійти в систему.",
+      "continue_button": "Продовжити",
+      "use_passkey_button": "Використовувати пароль",
+      "skip_passkey_link": "Не зараз"
     }
   }
 }

--- a/vi/auth.json
+++ b/vi/auth.json
@@ -85,7 +85,8 @@
       "use_username_link": "Chuyển sang tên đăng nhập",
       "use_email_or_username_link": "Chuyển sang tên đăng nhập hoặc số điện thoại",
       "translate_context": "Page where people enter their email to sign in to an existing Kinde account",
-      "please_select_an_option": "Vui lòng chọn một tùy chọn"
+      "please_select_an_option": "Vui lòng chọn một tùy chọn",
+      "sign_in_with_passkey_button": "Đăng nhập bằng mật khẩu"
     },
     "sign_up_page": {
       "page_title": "Đăng ký | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "Dùng thử miễn phí"
+    },
+    "passkey_setup_page": {
+      "heading": "Thiết lập mật khẩu",
+      "description": "Hãy sử dụng tính năng nhận diện sinh trắc học hoặc khóa bảo mật trên thiết bị của bạn để đăng nhập nhanh chóng trong lần tiếp theo.",
+      "continue_button": "Tiếp tục",
+      "use_passkey_button": "Sử dụng mật khẩu",
+      "skip_passkey_link": "Không phải bây giờ"
     }
   }
 }

--- a/zh-Hans/auth.json
+++ b/zh-Hans/auth.json
@@ -85,7 +85,8 @@
       "email_or_username_input_error_invalid": "输入有效的电子邮件或用户名",
       "use_username_link": "切换到用户名",
       "use_email_or_username_link": "切换到用户名或电子邮件",
-      "please_select_an_option": "请选择一个选项"
+      "please_select_an_option": "请选择一个选项",
+      "sign_in_with_passkey_button": "使用密钥登录"
     },
     "sign_up_page": {
       "page_title": "注册 | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "免费试用"
+    },
+    "passkey_setup_page": {
+      "heading": "设置密码",
+      "description": "下次登录时，请使用设备的生物识别功能或安全密钥快速登录。",
+      "continue_button": "继续",
+      "use_passkey_button": "使用密钥",
+      "skip_passkey_link": "现在不行"
     }
   }
 }

--- a/zh-Hant/auth.json
+++ b/zh-Hant/auth.json
@@ -85,7 +85,8 @@
       "email_or_username_input_error_invalid": "输入有效的电子邮件或用户名",
       "use_username_link": "切换到用户名",
       "use_email_or_username_link": "切换到用户名或电子邮件",
-      "please_select_an_option": "請選擇一項"
+      "please_select_an_option": "請選擇一項",
+      "sign_in_with_passkey_button": "使用密鑰登入"
     },
     "sign_up_page": {
       "page_title": "註冊 | ${business_name}",
@@ -567,6 +568,13 @@
     "plan_details_card_component": {
       "translate_context": "Component handling plan details card",
       "free_trial_for": "免費試用"
+    },
+    "passkey_setup_page": {
+      "heading": "設定密鑰",
+      "description": "下次登入時，請使用裝置的生物辨識功能或安全金鑰快速登入。",
+      "continue_button": "繼續",
+      "use_passkey_button": "使用密鑰",
+      "skip_passkey_link": "現在不行"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds English translation keys for passkey authentication in `en/auth.json`, supporting passkey sign-in on the login page and a new passkey setup flow after authentication.

## Changes

### Sign-in page (`sign_in_page`)

- **`sign_in_with_passkey_button`**: Button label for signing in with a passkey.

### Passkey setup page (`passkey_setup_page`)

New page section with strings for onboarding users to register a passkey:

| Key | Value |
|-----|-------|
| `heading` | Set up passkey |
| `description` | Use your device biometrics or security key to sign in quickly next time. |
| `continue_button` | Continue |
| `use_passkey_button` | Use passkey |
| `skip_passkey_link` | Not now |

## Why

These keys are required by the auth UI to expose passkey sign-in and optional passkey setup. English is the source locale; other languages can be auto-translated or updated in follow-up PRs after merge.

## Test plan

- [ ] Confirm `en/auth.json` is valid JSON and passes repo formatting checks