### PR TITLE
feat: add alert for trial ending soon on payment page

### DIFF
--- a/cs/auth.json
+++ b/cs/auth.json
@@ -561,7 +561,8 @@
       "frequency_annual": "rok",
       "subscribe_button": "Předplatit a zaplatit nyní",
       "alert_plan_has_expired": "Vaše zkušební období ${trial_length_in_days} dní pro tarif ${trial_plan_name} vypršelo. Pro pokračování prosím zadejte platební údaje",
-      "collect_payment_retry_message": "Vaše předchozí platba nebyla úspěšná. Zadejte jinou kartu a pokračujte."
+      "collect_payment_retry_message": "Vaše předchozí platba nebyla úspěšná. Zadejte jinou kartu a pokračujte.",
+      "alert_plan_trial_ending": "Vaše zkušební období tarifu ${trial_plan_name} brzy skončí. Chcete-li pokračovat, zadejte prosím platební údaje"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/da/auth.json
+++ b/da/auth.json
@@ -572,7 +572,8 @@
       "frequency_annual": "år",
       "subscribe_button": "Abonner og betal nu",
       "alert_plan_has_expired": "Din prøveperiode på ${trial_length_in_days} dage til ${trial_plan_name}-abonnementet er udløbet. Indtast betalingsoplysningerne for at fortsætte",
-      "collect_payment_retry_message": "Din tidligere betaling gik ikke igennem. Indtast et andet kort for at fortsætte."
+      "collect_payment_retry_message": "Din tidligere betaling gik ikke igennem. Indtast et andet kort for at fortsætte.",
+      "alert_plan_trial_ending": "Din prøveperiode for ${trial_plan_name}-abonnementet udløber snart. Indtast venligst betalingsoplysninger for at fortsætte"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/da/auth.json
+++ b/da/auth.json
@@ -573,7 +573,7 @@
       "subscribe_button": "Abonner og betal nu",
       "alert_plan_has_expired": "Din prøveperiode på ${trial_length_in_days} dage til ${trial_plan_name}-abonnementet er udløbet. Indtast betalingsoplysningerne for at fortsætte",
       "collect_payment_retry_message": "Din tidligere betaling gik ikke igennem. Indtast et andet kort for at fortsætte.",
-      "alert_plan_trial_ending": "Din prøveperiode for ${trial_plan_name}-abonnementet udløber snart. Indtast venligst betalingsoplysninger for at fortsætte"
+      "alert_plan_trial_ending": "Din prøveperiode for ${trial_plan_name}-abonnementet udløber snart. Indtast venligst betalingsoplysningerne for at fortsætte"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/de/auth.json
+++ b/de/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "Jahr",
       "subscribe_button": "Jetzt abonnieren und bezahlen",
       "alert_plan_has_expired": "Ihre ${trial_length_in_days}-tägige Testphase für den ${trial_plan_name}-Tarif ist abgelaufen. Bitte geben Sie Ihre Zahlungsdaten ein, um fortzufahren",
-      "collect_payment_retry_message": "Ihre vorherige Zahlung ist nicht erfolgreich gewesen. Geben Sie bitte eine andere Karte ein, um fortzufahren."
+      "collect_payment_retry_message": "Ihre vorherige Zahlung ist nicht erfolgreich gewesen. Geben Sie bitte eine andere Karte ein, um fortzufahren.",
+      "alert_plan_trial_ending": "Ihre Testphase für den ${trial_plan_name}-Tarif läuft bald ab. Bitte geben Sie Ihre Zahlungsdaten ein, um fortzufahren"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/el/auth.json
+++ b/el/auth.json
@@ -524,7 +524,8 @@
       "frequency_annual": "έτος",
       "subscribe_button": "Εγγραφή και πληρωμή τώρα",
       "alert_plan_has_expired": "Η δοκιμαστική περίοδος ${trial_length_in_days} ημερών για το πακέτο ${trial_plan_name} έχει λήξει. Παρακαλώ εισάγετε τα στοιχεία πληρωμής για να συνεχίσετε",
-      "collect_payment_retry_message": "Η προηγούμενη πληρωμή σας δεν ολοκληρώθηκε. Εισάγετε μια άλλη κάρτα για να συνεχίσετε."
+      "collect_payment_retry_message": "Η προηγούμενη πληρωμή σας δεν ολοκληρώθηκε. Εισάγετε μια άλλη κάρτα για να συνεχίσετε.",
+      "alert_plan_trial_ending": "Η δοκιμαστική περίοδος του πακέτου ${trial_plan_name} λήγει σύντομα. Παρακαλούμε εισάγετε τα στοιχεία πληρωμής για να συνεχίσετε"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/en-GB/auth.json
+++ b/en-GB/auth.json
@@ -545,6 +545,7 @@
       "subscribe_button": "Subscribe and pay now",
       "translate_context": "Page to collect the payment details for a new subscrition signup",
       "alert_plan_has_expired": "Your trial of ${trial_length_in_days} days to the ${trial_plan_name} plan has expired, please enter payment details to proceed",
+      "alert_plan_trial_ending": "Your trial of the ${trial_plan_name} plan is ending soon, please enter payment details to continue",
       "collect_payment_retry_message": "Your previous payment did not go through. Enter a different card to continue."
     },
     "mfa_use_phone_otp_page": {

--- a/en-US/auth.json
+++ b/en-US/auth.json
@@ -543,6 +543,7 @@
       "subscribe_button": "Subscribe and pay now",
       "translate_context": "Page to collect the payment details for a new subscrition signup",
       "alert_plan_has_expired": "Your trial of ${trial_length_in_days} days to the ${trial_plan_name} plan has expired, please enter payment details to proceed",
+      "alert_plan_trial_ending": "Your trial of the ${trial_plan_name} plan is ending soon, please enter payment details to continue",
       "collect_payment_retry_message": "Your previous payment did not go through. Enter a different card to continue."
     },
     "mfa_use_phone_otp_page": {

--- a/en/auth.json
+++ b/en/auth.json
@@ -566,6 +566,7 @@
     "collect_payment_details_page": {
       "translate_context": "Page to collect the payment details for a new subscription signup",
       "alert_plan_has_expired": "Your trial of ${trial_length_in_days} days to the ${trial_plan_name} plan has expired, please enter payment details to proceed",
+      "alert_plan_trial_ending": "Your trial of the ${trial_plan_name} plan is ending soon, please enter payment details to continue",
       "collect_payment_retry_message": "Your previous payment did not go through. Enter a different card to continue.",
       "page_title": "Subscription payment | ${business_name}",
       "heading": "Subscription payment",

--- a/es/auth.json
+++ b/es/auth.json
@@ -572,7 +572,8 @@
       "frequency_annual": "año",
       "subscribe_button": "Suscríbase y pague ahora",
       "alert_plan_has_expired": "Tu periodo de prueba de ${trial_length_in_days} días del plan ${trial_plan_name} ha caducado. Introduce los datos de pago para continuar",
-      "collect_payment_retry_message": "Tu pago anterior no se ha procesado. Introduce otra tarjeta para continuar."
+      "collect_payment_retry_message": "Tu pago anterior no se ha procesado. Introduce otra tarjeta para continuar.",
+      "alert_plan_trial_ending": "Tu periodo de prueba del plan ${trial_plan_name} está a punto de finalizar. Introduce los datos de pago para continuar."
     },
     "general": {
       "translate_context": "General simple messages",

--- a/et/auth.json
+++ b/et/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "aasta",
       "subscribe_button": "Telli ja maksa nüüd",
       "alert_plan_has_expired": "Teie ${trial_length_in_days}-päevane prooviperiood ${trial_plan_name}-paketile on lõppenud. Palun sisestage makseandmed, et jätkata",
-      "collect_payment_retry_message": "Teie eelmine makse ei läinud läbi. Sisestage teine kaart, et jätkata."
+      "collect_payment_retry_message": "Teie eelmine makse ei läinud läbi. Sisestage teine kaart, et jätkata.",
+      "alert_plan_trial_ending": "Teie ${trial_plan_name} paketi prooviperiood lõpeb varsti. Palun sisestage makseandmed, et jätkata"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/fr/auth.json
+++ b/fr/auth.json
@@ -562,7 +562,7 @@
       "subscribe_button": "S'abonner et payer maintenant",
       "alert_plan_has_expired": "Votre période d'essai de ${trial_length_in_days} jours pour le forfait ${trial_plan_name} a expiré. Veuillez saisir vos informations de paiement pour continuer",
       "collect_payment_retry_message": "Votre paiement précédent n'a pas abouti. Veuillez saisir une autre carte pour continuer.",
-      "alert_plan_trial_ending": "Votre période d'essai du forfait ${trial_plan_name} touche à sa fin. Veuillez saisir vos informations de paiement pour continuer"
+      "alert_plan_trial_ending": "Votre période d'essai du forfait ${trial_plan_name} arrive bientôt à terme. Veuillez saisir vos informations de paiement pour continuer"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/fr/auth.json
+++ b/fr/auth.json
@@ -561,7 +561,8 @@
       "frequency_annual": "année",
       "subscribe_button": "S'abonner et payer maintenant",
       "alert_plan_has_expired": "Votre période d'essai de ${trial_length_in_days} jours pour le forfait ${trial_plan_name} a expiré. Veuillez saisir vos informations de paiement pour continuer",
-      "collect_payment_retry_message": "Votre paiement précédent n'a pas abouti. Veuillez saisir une autre carte pour continuer."
+      "collect_payment_retry_message": "Votre paiement précédent n'a pas abouti. Veuillez saisir une autre carte pour continuer.",
+      "alert_plan_trial_ending": "Votre période d'essai du forfait ${trial_plan_name} touche à sa fin. Veuillez saisir vos informations de paiement pour continuer"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/he/auth.json
+++ b/he/auth.json
@@ -572,7 +572,8 @@
       "frequency_annual": "שנה",
       "subscribe_button": "הירשם ותשלם עכשיו",
       "alert_plan_has_expired": "תקופת הניסיון שלך בת ${trial_length_in_days} ימים לתוכנית ${trial_plan_name} הסתיימה. אנא הזן את פרטי התשלום כדי להמשיך",
-      "collect_payment_retry_message": "התשלום הקודם שלך לא עבר. הזן כרטיס אחר כדי להמשיך."
+      "collect_payment_retry_message": "התשלום הקודם שלך לא עבר. הזן כרטיס אחר כדי להמשיך.",
+      "alert_plan_trial_ending": "תקופת הניסיון שלך בתוכנית ${trial_plan_name} עומדת להסתיים בקרוב. אנא הזן את פרטי התשלום כדי להמשיך"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/hu/auth.json
+++ b/hu/auth.json
@@ -561,7 +561,7 @@
       "subscribe_button": "Feliratkozás és fizetés most",
       "alert_plan_has_expired": "A ${trial_length_in_days} napos próbaidőszak a ${trial_plan_name} csomagra lejárt. Kérjük, adja meg a fizetési adatokat a folytatáshoz",
       "collect_payment_retry_message": "A korábbi fizetés nem sikerült. Adjon meg egy másik kártyát a folytatáshoz.",
-      "alert_plan_trial_ending": "A ${trial_plan_name} csomag próbaidőszaka hamarosan lejár. Kérjük, adja meg a fizetési adatokat a folytatáshoz"
+      "alert_plan_trial_ending": "A ${trial_plan_name} csomag próbaidőszaka hamarosan lejár, kérjük, adja meg a fizetési adatokat a folytatáshoz"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/hu/auth.json
+++ b/hu/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "év",
       "subscribe_button": "Feliratkozás és fizetés most",
       "alert_plan_has_expired": "A ${trial_length_in_days} napos próbaidőszak a ${trial_plan_name} csomagra lejárt. Kérjük, adja meg a fizetési adatokat a folytatáshoz",
-      "collect_payment_retry_message": "A korábbi fizetés nem sikerült. Adjon meg egy másik kártyát a folytatáshoz."
+      "collect_payment_retry_message": "A korábbi fizetés nem sikerült. Adjon meg egy másik kártyát a folytatáshoz.",
+      "alert_plan_trial_ending": "A ${trial_plan_name} csomag próbaidőszaka hamarosan lejár. Kérjük, adja meg a fizetési adatokat a folytatáshoz"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/id/auth.json
+++ b/id/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "tahun",
       "subscribe_button": "Berlangganan dan bayar sekarang",
       "alert_plan_has_expired": "Masa uji coba Anda selama ${trial_length_in_days} hari untuk paket ${trial_plan_name} telah berakhir. Silakan masukkan rincian pembayaran untuk melanjutkan",
-      "collect_payment_retry_message": "Pembayaran Anda sebelumnya tidak berhasil. Silakan masukkan kartu yang berbeda untuk melanjutkan."
+      "collect_payment_retry_message": "Pembayaran Anda sebelumnya tidak berhasil. Silakan masukkan kartu yang berbeda untuk melanjutkan.",
+      "alert_plan_trial_ending": "Masa uji coba paket ${trial_plan_name} Anda akan segera berakhir, silakan masukkan rincian pembayaran untuk melanjutkan"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/it/auth.json
+++ b/it/auth.json
@@ -562,7 +562,8 @@
       "frequency_annual": "anno",
       "subscribe_button": "Abbonati e paga ora",
       "alert_plan_has_expired": "Il periodo di prova di ${trial_length_in_days} giorni del piano ${trial_plan_name} è scaduto. Inserisci i dati di pagamento per procedere",
-      "collect_payment_retry_message": "Il tuo precedente pagamento non è andato a buon fine. Inserisci una carta diversa per continuare."
+      "collect_payment_retry_message": "Il tuo precedente pagamento non è andato a buon fine. Inserisci una carta diversa per continuare.",
+      "alert_plan_trial_ending": "Il periodo di prova del piano ${trial_plan_name} sta per scadere; inserisci i dati di pagamento per continuare"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/ja/auth.json
+++ b/ja/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "年",
       "subscribe_button": "今すぐ購読して支払う",
       "alert_plan_has_expired": "${trial_length_in_days}日間の${trial_plan_name}プランのトライアル期間が終了しました。手続きを進めるには、お支払い情報を入力してください",
-      "collect_payment_retry_message": "前回の支払いが正常に処理されませんでした。別のカード情報を入力して手続きを続けてください。"
+      "collect_payment_retry_message": "前回の支払いが正常に処理されませんでした。別のカード情報を入力して手続きを続けてください。",
+      "alert_plan_trial_ending": "${trial_plan_name}プランの無料体験期間がまもなく終了します。引き続きご利用いただくには、お支払い情報を入力してください"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/ko/auth.json
+++ b/ko/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "년",
       "subscribe_button": "지금 구독하고 결제하기",
       "alert_plan_has_expired": "${trial_length_in_days}일간의 ${trial_plan_name} 요금제 체험 기간이 만료되었습니다. 계속 진행하려면 결제 정보를 입력해 주세요",
-      "collect_payment_retry_message": "이전 결제가 처리되지 않았습니다. 계속하려면 다른 카드를 입력해 주세요."
+      "collect_payment_retry_message": "이전 결제가 처리되지 않았습니다. 계속하려면 다른 카드를 입력해 주세요.",
+      "alert_plan_trial_ending": "${trial_plan_name} 요금제의 체험 기간이 곧 종료됩니다. 계속 이용하시려면 결제 정보를 입력해 주세요."
     },
     "general": {
       "translate_context": "General simple messages",

--- a/lt/auth.json
+++ b/lt/auth.json
@@ -561,7 +561,7 @@
       "subscribe_button": "Prenumeruokite ir sumokėkite dabar",
       "alert_plan_has_expired": "Jūsų ${trial_length_in_days} dienų bandomoji versija pagal ${trial_plan_name} planą baigėsi. Norėdami tęsti, įveskite mokėjimo duomenis",
       "collect_payment_retry_message": "Jūsų ankstesnis mokėjimas nebuvo įvykdytas. Norėdami tęsti, įveskite kitą kortelę.",
-      "alert_plan_trial_ending": "Jūsų ${trial_plan_name} plano bandomasis laikotarpis netrukus baigsis, todėl, norėdami tęsti naudojimąsi paslauga, įveskite mokėjimo duomenis"
+      "alert_plan_trial_ending": "Jūsų ${trial_plan_name} plano bandomasis laikotarpis netrukus baigsis. Norėdami tęsti, įveskite mokėjimo duomenis"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/lt/auth.json
+++ b/lt/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "metus",
       "subscribe_button": "Prenumeruokite ir sumokėkite dabar",
       "alert_plan_has_expired": "Jūsų ${trial_length_in_days} dienų bandomoji versija pagal ${trial_plan_name} planą baigėsi. Norėdami tęsti, įveskite mokėjimo duomenis",
-      "collect_payment_retry_message": "Jūsų ankstesnis mokėjimas nebuvo įvykdytas. Norėdami tęsti, įveskite kitą kortelę."
+      "collect_payment_retry_message": "Jūsų ankstesnis mokėjimas nebuvo įvykdytas. Norėdami tęsti, įveskite kitą kortelę.",
+      "alert_plan_trial_ending": "Jūsų ${trial_plan_name} plano bandomasis laikotarpis netrukus baigsis, todėl, norėdami tęsti naudojimąsi paslauga, įveskite mokėjimo duomenis"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/lv/auth.json
+++ b/lv/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "gads",
       "subscribe_button": "Abonēt un maksāt tagad",
       "alert_plan_has_expired": "Jūsu ${trial_length_in_days} dienu izmēģinājuma periods ${trial_plan_name} plānam ir beidzies. Lūdzu, ievadiet maksājuma informāciju, lai turpinātu",
-      "collect_payment_retry_message": "Jūsu iepriekšējais maksājums netika apstiprināts. Lai turpinātu, ievadiet citu karti."
+      "collect_payment_retry_message": "Jūsu iepriekšējais maksājums netika apstiprināts. Lai turpinātu, ievadiet citu karti.",
+      "alert_plan_trial_ending": "Jūsu ${trial_plan_name} plāna izmēģinājuma periods drīz beigsies. Lūdzu, ievadiet maksājuma informāciju, lai turpinātu"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/nl/auth.json
+++ b/nl/auth.json
@@ -573,7 +573,8 @@
       "frequency_annual": "jaar",
       "subscribe_button": "Abonneer en betaal nu",
       "alert_plan_has_expired": "Uw proefperiode van ${trial_length_in_days} dagen voor het ${trial_plan_name}-abonnement is verlopen. Voer uw betalingsgegevens in om door te gaan",
-      "collect_payment_retry_message": "Uw vorige betaling is niet gelukt. Voer een andere kaart in om door te gaan."
+      "collect_payment_retry_message": "Uw vorige betaling is niet gelukt. Voer een andere kaart in om door te gaan.",
+      "alert_plan_trial_ending": "Uw proefperiode voor het ${trial_plan_name}-abonnement loopt binnenkort af. Voer uw betalingsgegevens in om door te gaan"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/pl/auth.json
+++ b/pl/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "rok",
       "subscribe_button": "Subskrybuj i zapłać teraz",
       "alert_plan_has_expired": "Twój ${trial_length_in_days}-dniowy okres próbny planu ${trial_plan_name} wygasł. Wprowadź dane dotyczące płatności, aby kontynuować",
-      "collect_payment_retry_message": "Poprzednia płatność nie została zrealizowana. Wprowadź dane innej karty, aby kontynuować."
+      "collect_payment_retry_message": "Poprzednia płatność nie została zrealizowana. Wprowadź dane innej karty, aby kontynuować.",
+      "alert_plan_trial_ending": "Twój okres próbny planu ${trial_plan_name} wkrótce dobiegnie końca. Aby kontynuować, wprowadź dane do płatności"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/pt-BR/auth.json
+++ b/pt-BR/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "ano",
       "subscribe_button": "Assine e pague agora",
       "alert_plan_has_expired": "Seu período de avaliação de ${trial_length_in_days} dias do plano ${trial_plan_name} expirou. Insira os detalhes de pagamento para continuar",
-      "collect_payment_retry_message": "Seu pagamento anterior não foi processado. Insira um cartão diferente para continuar."
+      "collect_payment_retry_message": "Seu pagamento anterior não foi processado. Insira um cartão diferente para continuar.",
+      "alert_plan_trial_ending": "Seu período de teste do plano ${trial_plan_name} está prestes a terminar. Insira os dados de pagamento para continuar"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/pt-BR/auth.json
+++ b/pt-BR/auth.json
@@ -561,7 +561,7 @@
       "subscribe_button": "Assine e pague agora",
       "alert_plan_has_expired": "Seu período de avaliação de ${trial_length_in_days} dias do plano ${trial_plan_name} expirou. Insira os detalhes de pagamento para continuar",
       "collect_payment_retry_message": "Seu pagamento anterior não foi processado. Insira um cartão diferente para continuar.",
-      "alert_plan_trial_ending": "Seu período de teste do plano ${trial_plan_name} está prestes a terminar. Insira os dados de pagamento para continuar"
+      "alert_plan_trial_ending": "Seu período de teste do plano ${trial_plan_name} está prestes a terminar. Insira os detalhes de pagamento para continuar"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/pt-PT/auth.json
+++ b/pt-PT/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "ano",
       "subscribe_button": "Subscrever e pagar agora",
       "alert_plan_has_expired": "O seu período de avaliação de ${trial_length_in_days} dias do plano ${trial_plan_name} expirou. Introduza os dados de pagamento para continuar",
-      "collect_payment_retry_message": "O seu pagamento anterior não foi processado. Introduza um cartão diferente para continuar."
+      "collect_payment_retry_message": "O seu pagamento anterior não foi processado. Introduza um cartão diferente para continuar.",
+      "alert_plan_trial_ending": "O seu período de avaliação do plano ${trial_plan_name} está prestes a terminar. Introduza os dados de pagamento para continuar"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/ro/auth.json
+++ b/ro/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "an",
       "subscribe_button": "Abonați-vă și plătiți acum",
       "alert_plan_has_expired": "Perioada de probă de ${trial_length_in_days} zile pentru planul ${trial_plan_name} a expirat. Vă rugăm să introduceți detaliile de plată pentru a continua",
-      "collect_payment_retry_message": "Plata anterioară nu a fost procesată. Introduceți un alt card pentru a continua."
+      "collect_payment_retry_message": "Plata anterioară nu a fost procesată. Introduceți un alt card pentru a continua.",
+      "alert_plan_trial_ending": "Perioada de probă a planului ${trial_plan_name} se va încheia în curând. Vă rugăm să introduceți detaliile de plată pentru a continua"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/ru/auth.json
+++ b/ru/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "год",
       "subscribe_button": "Подписаться и оплатить сейчас",
       "alert_plan_has_expired": "Ваш пробный период ${trial_length_in_days} дней по тарифу ${trial_plan_name} истек. Пожалуйста, введите платежные данные, чтобы продолжить",
-      "collect_payment_retry_message": "Ваш предыдущий платеж не прошел. Введите данные другой карты, чтобы продолжить."
+      "collect_payment_retry_message": "Ваш предыдущий платеж не прошел. Введите данные другой карты, чтобы продолжить.",
+      "alert_plan_trial_ending": "Ваш пробный период по тарифу ${trial_plan_name} скоро заканчивается. Пожалуйста, введите платежные данные, чтобы продолжить"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/sk/auth.json
+++ b/sk/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "rok",
       "subscribe_button": "Predplaťte si a zaplaťte teraz",
       "alert_plan_has_expired": "Vaša skúšobná verzia plánu ${trial_plan_name} na ${trial_length_in_days} dní vypršala. Ak chcete pokračovať, zadajte platobné údaje.",
-      "collect_payment_retry_message": "Vaša predchádzajúca platba nebola úspešná. Zadajte inú kartu, aby ste mohli pokračovať."
+      "collect_payment_retry_message": "Vaša predchádzajúca platba nebola úspešná. Zadajte inú kartu, aby ste mohli pokračovať.",
+      "alert_plan_trial_ending": "Vaše skúšobné obdobie plánu ${trial_plan_name} sa čoskoro končí. Ak chcete pokračovať, zadajte platobné údaje."
     },
     "general": {
       "translate_context": "General simple messages",

--- a/sk/auth.json
+++ b/sk/auth.json
@@ -561,7 +561,7 @@
       "subscribe_button": "Predplaťte si a zaplaťte teraz",
       "alert_plan_has_expired": "Vaša skúšobná verzia plánu ${trial_plan_name} na ${trial_length_in_days} dní vypršala. Ak chcete pokračovať, zadajte platobné údaje.",
       "collect_payment_retry_message": "Vaša predchádzajúca platba nebola úspešná. Zadajte inú kartu, aby ste mohli pokračovať.",
-      "alert_plan_trial_ending": "Vaše skúšobné obdobie plánu ${trial_plan_name} sa čoskoro končí. Ak chcete pokračovať, zadajte platobné údaje."
+      "alert_plan_trial_ending": "Vaše skúšobné obdobie plánu ${trial_plan_name} sa čoskoro končí. Ak chcete pokračovať, zadajte prosím platobné údaje"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/sv/auth.json
+++ b/sv/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "år",
       "subscribe_button": "Prenumerera och betala nu",
       "alert_plan_has_expired": "Din provperiod på ${trial_length_in_days} dagar för planen ${trial_plan_name} har löpt ut. Ange betalningsuppgifter för att fortsätta",
-      "collect_payment_retry_message": "Din tidigare betalning gick inte igenom. Ange ett annat kort för att fortsätta."
+      "collect_payment_retry_message": "Din tidigare betalning gick inte igenom. Ange ett annat kort för att fortsätta.",
+      "alert_plan_trial_ending": "Din provperiod för ${trial_plan_name}-planen löper snart ut. Ange betalningsuppgifter för att fortsätta"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/th/auth.json
+++ b/th/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "ปี",
       "subscribe_button": "สมัครสมาชิกและชำระเงินตอนนี้",
       "alert_plan_has_expired": "การทดลองใช้ ${trial_length_in_days} วันสำหรับแผน ${trial_plan_name} ของคุณหมดอายุแล้ว กรุณากรอกรายละเอียดการชำระเงินเพื่อดำเนินการต่อ",
-      "collect_payment_retry_message": "การชำระเงินครั้งก่อนของคุณไม่สำเร็จ กรุณากรอกบัตรอื่นเพื่อดำเนินการต่อ"
+      "collect_payment_retry_message": "การชำระเงินครั้งก่อนของคุณไม่สำเร็จ กรุณากรอกบัตรอื่นเพื่อดำเนินการต่อ",
+      "alert_plan_trial_ending": "ช่วงทดลองใช้แผน ${trial_plan_name} ของคุณจะสิ้นสุดในไม่ช้า โปรดกรอกข้อมูลการชำระเงินเพื่อต่ออายุ"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/tr/auth.json
+++ b/tr/auth.json
@@ -575,7 +575,8 @@
       "frequency_annual": "yıl",
       "subscribe_button": "Abone olun ve şimdi ödeyin",
       "alert_plan_has_expired": "${trial_length_in_days} günlük ${trial_plan_name} planı deneme süreniz sona ermiştir. Devam etmek için lütfen ödeme bilgilerinizi girin",
-      "collect_payment_retry_message": "Önceki ödemeniz gerçekleştirilemedi. Devam etmek için farklı bir kart bilgisi girin."
+      "collect_payment_retry_message": "Önceki ödemeniz gerçekleştirilemedi. Devam etmek için farklı bir kart bilgisi girin.",
+      "alert_plan_trial_ending": "${trial_plan_name} planının deneme süresi yakında sona erecek, devam etmek için lütfen ödeme bilgilerinizi girin"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/tr/auth.json
+++ b/tr/auth.json
@@ -576,7 +576,7 @@
       "subscribe_button": "Abone olun ve şimdi ödeyin",
       "alert_plan_has_expired": "${trial_length_in_days} günlük ${trial_plan_name} planı deneme süreniz sona ermiştir. Devam etmek için lütfen ödeme bilgilerinizi girin",
       "collect_payment_retry_message": "Önceki ödemeniz gerçekleştirilemedi. Devam etmek için farklı bir kart bilgisi girin.",
-      "alert_plan_trial_ending": "${trial_plan_name} planının deneme süresi yakında sona erecek, devam etmek için lütfen ödeme bilgilerinizi girin"
+      "alert_plan_trial_ending": "${trial_plan_name} planının deneme süreniz yakında sona erecek, devam etmek için lütfen ödeme bilgilerinizi girin"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/uk/auth.json
+++ b/uk/auth.json
@@ -561,7 +561,8 @@
       "frequency_annual": "рік",
       "subscribe_button": "Підпишіться та сплатіть зараз",
       "alert_plan_has_expired": "Ваш пробний період ${trial_length_in_days} днів за тарифним планом ${trial_plan_name} закінчився. Введіть платіжні дані, щоб продовжити",
-      "collect_payment_retry_message": "Ваш попередній платіж не пройшов. Введіть дані іншої картки, щоб продовжити."
+      "collect_payment_retry_message": "Ваш попередній платіж не пройшов. Введіть дані іншої картки, щоб продовжити.",
+      "alert_plan_trial_ending": "Ваш пробний період за тарифним планом ${trial_plan_name} незабаром закінчується. Будь ласка, введіть платіжні реквізити, щоб продовжити користування"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/vi/auth.json
+++ b/vi/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "năm",
       "subscribe_button": "Đăng ký và thanh toán ngay",
       "alert_plan_has_expired": "Thời gian dùng thử ${trial_length_in_days} ngày cho gói ${trial_plan_name} của bạn đã hết hạn, vui lòng nhập thông tin thanh toán để tiếp tục",
-      "collect_payment_retry_message": "Giao dịch thanh toán trước đó của bạn không thành công. Vui lòng nhập thông tin thẻ khác để tiếp tục."
+      "collect_payment_retry_message": "Giao dịch thanh toán trước đó của bạn không thành công. Vui lòng nhập thông tin thẻ khác để tiếp tục.",
+      "alert_plan_trial_ending": "Thời gian dùng thử gói ${trial_plan_name} của bạn sắp kết thúc, vui lòng nhập thông tin thanh toán để tiếp tục"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/zh-Hans/auth.json
+++ b/zh-Hans/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "年",
       "subscribe_button": "现在订阅并付款",
       "alert_plan_has_expired": "您对${trial_length_in_days}计划的${trial_plan_name}天试用期已到期，请输入付款信息以继续",
-      "collect_payment_retry_message": "您之前的付款未成功。请输入另一张卡继续操作。"
+      "collect_payment_retry_message": "您之前的付款未成功。请输入另一张卡继续操作。",
+      "alert_plan_trial_ending": "您对${trial_plan_name}套餐的试用期即将结束，请输入付款信息以继续使用"
     },
     "general": {
       "translate_context": "General simple messages",

--- a/zh-Hant/auth.json
+++ b/zh-Hant/auth.json
@@ -560,7 +560,8 @@
       "frequency_annual": "年",
       "subscribe_button": "现在订阅并付款",
       "alert_plan_has_expired": "您對 ${trial_length_in_days} 方案為期 ${trial_plan_name} 天的試用期已到期，請輸入付款資訊以繼續",
-      "collect_payment_retry_message": "您的上一筆付款未成功。請輸入另一張卡片以繼續。"
+      "collect_payment_retry_message": "您的上一筆付款未成功。請輸入另一張卡片以繼續。",
+      "alert_plan_trial_ending": "您對 ${trial_plan_name} 方案的試用期即將結束，請輸入付款資訊以繼續使用"
     },
     "general": {
       "translate_context": "General simple messages",


### PR DESCRIPTION
Distinguish mid-trial card collection from an expired trial so the collect-payment banner no longer claims the trial has ended early.

# Explain your changes

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
