### PR TITLE
feat: add choose MFA method recovery code strings

### DIFF
--- a/auth-schema.json
+++ b/auth-schema.json
@@ -617,6 +617,12 @@
             "email_button": {
               "type": "string"
             },
+            "lost_your_device_description": {
+              "type": "string"
+            },
+            "lost_your_device_link": {
+              "type": "string"
+            },
             "do_not_use_mfa_link": {
               "type": "string"
             }

--- a/cs/auth.json
+++ b/cs/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "SMS",
       "email_button": "E-mail",
       "do_not_use_mfa_link": "Nepoužívat vícefaktorovou autentizaci",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Ztratili jste zařízení?",
+      "lost_your_device_link": "Použijte obnovovací kód"
     },
     "account_locked_page": {
       "page_title": "Účet uzamčen | ${business_name}",

--- a/da/auth.json
+++ b/da/auth.json
@@ -154,7 +154,9 @@
       "sms_button": "SMS",
       "email_button": "E-mail",
       "do_not_use_mfa_link": "Brug ikke multifaktorgodkendelse",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Har du mistet din enhed?",
+      "lost_your_device_link": "Brug en gendannelseskode"
     },
     "account_locked_page": {
       "page_title": "Konto er låst | ${business_name}",

--- a/de/auth.json
+++ b/de/auth.json
@@ -234,7 +234,9 @@
       "email_button": "E-Mail",
       "sms_button": "SMS",
       "do_not_use_mfa_link": "Keine Multi-Faktor-Authentifizierung verwenden",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Haben Sie Ihr Gerät verloren?",
+      "lost_your_device_link": "Wiederherstellungscode verwenden"
     },
     "recovery_codes_page": {
       "page_title": "Wiederherstellungscodes | ${business_name}",

--- a/el/auth.json
+++ b/el/auth.json
@@ -160,7 +160,9 @@
       "authenticator_app_button": "Εφαρμογή αυθεντικοποίησης",
       "sms_button": "SMS",
       "email_button": "Email",
-      "do_not_use_mfa_link": "Να μην χρησιμοποιηθεί αυθεντικοποίηση πολλαπλών παραγόντων"
+      "do_not_use_mfa_link": "Να μην χρησιμοποιηθεί αυθεντικοποίηση πολλαπλών παραγόντων",
+      "lost_your_device_description": "Χάσατε τη συσκευή σας;",
+      "lost_your_device_link": "Χρησιμοποιήστε έναν κωδικό ανάκτησης"
     },
     "account_locked_page": {
       "page_title": "Κλειδωμένος λογαριασμός | ${business_name}",

--- a/en-GB/auth.json
+++ b/en-GB/auth.json
@@ -150,6 +150,8 @@
       "authenticator_app_button": "Authenticator app",
       "sms_button": "SMS",
       "email_button": "Email",
+      "lost_your_device_description": "Lost your device?",
+      "lost_your_device_link": "Use a recovery code",
       "do_not_use_mfa_link": "Don't use multi-factor authentication",
       "translate_context": "Page to choose a preferred MFA method"
     },

--- a/en-US/auth.json
+++ b/en-US/auth.json
@@ -150,6 +150,8 @@
       "authenticator_app_button": "Authenticator app",
       "sms_button": "SMS",
       "email_button": "Email",
+      "lost_your_device_description": "Lost your device?",
+      "lost_your_device_link": "Use a recovery code",
       "do_not_use_mfa_link": "Don't use multi-factor authentication",
       "translate_context": "Page to choose a preferred MFA method"
     },

--- a/en/auth.json
+++ b/en/auth.json
@@ -168,6 +168,8 @@
       "authenticator_app_button": "Authenticator app",
       "sms_button": "SMS",
       "email_button": "Email",
+      "lost_your_device_description": "Lost your device?",
+      "lost_your_device_link": "Use a recovery code",
       "do_not_use_mfa_link": "Don't use multi-factor authentication"
     },
     "account_locked_page": {

--- a/es/auth.json
+++ b/es/auth.json
@@ -68,7 +68,9 @@
       "email_button": "Correo electrónico",
       "sms_button": "SMS",
       "do_not_use_mfa_link": "No utilice la autenticación multifactor",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "¿Has perdido tu dispositivo?",
+      "lost_your_device_link": "Utilizar un código de recuperación"
     },
     "choose_organization_page": {
       "page_title": "Seleccionar organización | ${business_name}",

--- a/et/auth.json
+++ b/et/auth.json
@@ -168,7 +168,9 @@
       "sms_button": "SMS",
       "email_button": "E-post",
       "do_not_use_mfa_link": "Ära kasuta mitmeastmelist autentimist",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Kas kaotasite oma seadme?",
+      "lost_your_device_link": "Kasuta taastamiskoodi"
     },
     "account_locked_page": {
       "page_title": "Konto lukustatud | ${business_name}",

--- a/fr/auth.json
+++ b/fr/auth.json
@@ -152,7 +152,9 @@
       "sms_button": "SMS",
       "email_button": "Email",
       "do_not_use_mfa_link": "Ne pas utiliser l'authentification multifacteur",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Vous avez perdu votre appareil ?",
+      "lost_your_device_link": "Utiliser un code de récupération"
     },
     "account_locked_page": {
       "page_title": "Compte verrouillé | ${business_name}",

--- a/he/auth.json
+++ b/he/auth.json
@@ -98,7 +98,9 @@
       "email_button": "דואר אלקטרוני",
       "sms_button": "SMS",
       "do_not_use_mfa_link": "אל תשתמש באימות רב-גורמים",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "איבדת את המכשיר שלך?",
+      "lost_your_device_link": "השתמש בקוד שחזור"
     },
     "choose_organization_page": {
       "page_title": "בחירת ארגון | ${business_name}",

--- a/hu/auth.json
+++ b/hu/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "SMS",
       "email_button": "E-mail",
       "do_not_use_mfa_link": "Ne használjon többlépcsős azonosítást",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Elvesztette az eszközét?",
+      "lost_your_device_link": "Helyreállítási kód használata"
     },
     "account_locked_page": {
       "page_title": "Fiók zárolva | ${business_name}",

--- a/id/auth.json
+++ b/id/auth.json
@@ -139,7 +139,9 @@
       "sms_button": "SMS",
       "email_button": "Email",
       "do_not_use_mfa_link": "Jangan gunakan autentikasi multi-faktor",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Perangkat Anda hilang?",
+      "lost_your_device_link": "Gunakan kode pemulihan"
     },
     "account_locked_page": {
       "page_title": "Akun dikunci | ${business_name}",

--- a/it/auth.json
+++ b/it/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "SMS",
       "email_button": "Email",
       "do_not_use_mfa_link": "Non usare l'autenticazione a due fattori",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Hai smarrito il tuo dispositivo?",
+      "lost_your_device_link": "Utilizza un codice di recupero"
     },
     "account_locked_page": {
       "page_title": "Account bloccato | ${business_name}",

--- a/ja/auth.json
+++ b/ja/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "SMS",
       "email_button": "メール",
       "do_not_use_mfa_link": "多要素認証を使用しない",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "デバイスを紛失しましたか？",
+      "lost_your_device_link": "リカバリーコードを使用する"
     },
     "account_locked_page": {
       "page_title": "アカウントがロックされました | ${business_name}",

--- a/ko/auth.json
+++ b/ko/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "SMS",
       "email_button": "이메일",
       "do_not_use_mfa_link": "2단계 인증을 쓰지 않을래요",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "기기를 분실하셨나요?",
+      "lost_your_device_link": "복구 코드 사용하기"
     },
     "account_locked_page": {
       "page_title": "계정 잠김 | ${business_name}",

--- a/lt/auth.json
+++ b/lt/auth.json
@@ -168,7 +168,9 @@
       "authenticator_app_button": "Autentifikatoriaus programa",
       "sms_button": "SMS",
       "email_button": "El. paštas",
-      "do_not_use_mfa_link": "Nenaudoti kelių dalių autentikacijos"
+      "do_not_use_mfa_link": "Nenaudoti kelių dalių autentikacijos",
+      "lost_your_device_description": "Praradote savo įrenginį?",
+      "lost_your_device_link": "Naudokite atkūrimo kodą"
     },
     "account_locked_page": {
       "translate_context": "Page shown when a user is locked out due to too many failed attempts",

--- a/lv/auth.json
+++ b/lv/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "SMS",
       "email_button": "E-pasts",
       "do_not_use_mfa_link": "Neizmantot daudzfaktoru autentifikāciju",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Pazaudējāt savu ierīci?",
+      "lost_your_device_link": "Izmantojiet atjaunošanas kodu"
     },
     "account_locked_page": {
       "page_title": "Konts bloķēts | ${business_name}",

--- a/nl/auth.json
+++ b/nl/auth.json
@@ -68,7 +68,9 @@
       "email_button": "E-mail",
       "sms_button": "SMS",
       "do_not_use_mfa_link": "Gebruik geen meervoudige authenticatie",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Bent u uw apparaat kwijtgeraakt?",
+      "lost_your_device_link": "Gebruik een herstelcode"
     },
     "choose_organization_page": {
       "page_title": "Selecteer organisatie | ${business_name}",

--- a/pl/auth.json
+++ b/pl/auth.json
@@ -169,7 +169,9 @@
       "sms_button": "SMS",
       "email_button": "E-mail",
       "do_not_use_mfa_link": "Nie używaj autoryzacji wieloetapowej",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Zgubiłeś urządzenie?",
+      "lost_your_device_link": "Użyj kodu odzyskiwania"
     },
     "account_locked_page": {
       "page_title": "Konto zablokowane | ${business_name}",

--- a/pt-BR/auth.json
+++ b/pt-BR/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "SMS",
       "email_button": "E-mail",
       "do_not_use_mfa_link": "Não use autenticação multifator",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Perdeu seu dispositivo?",
+      "lost_your_device_link": "Use um código de recuperação"
     },
     "account_locked_page": {
       "page_title": "Conta bloqueada | ${business_name}",

--- a/pt-PT/auth.json
+++ b/pt-PT/auth.json
@@ -169,7 +169,9 @@
       "sms_button": "SMS",
       "email_button": "E-mail",
       "do_not_use_mfa_link": "Não use autenticação multifator",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Perdeu o seu dispositivo?",
+      "lost_your_device_link": "Utilizar um código de recuperação"
     },
     "account_locked_page": {
       "page_title": "Conta bloqueada | ${business_name}",

--- a/ro/auth.json
+++ b/ro/auth.json
@@ -169,7 +169,9 @@
       "sms_button": "SMS",
       "email_button": "Email",
       "do_not_use_mfa_link": "Nu folosiți autentificarea prin factori multipli",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Ți-ai pierdut dispozitivul?",
+      "lost_your_device_link": "Utilizați un cod de recuperare"
     },
     "account_locked_page": {
       "page_title": "Cont blocat | ${business_name}",

--- a/ru/auth.json
+++ b/ru/auth.json
@@ -169,7 +169,9 @@
       "sms_button": "СМС",
       "email_button": "Электронная почта",
       "do_not_use_mfa_link": "Не использовать MFA",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Потеряли устройство?",
+      "lost_your_device_link": "Используйте код восстановления"
     },
     "account_locked_page": {
       "page_title": "Ваш аккаунт заблокирован | ${business_name}",

--- a/sk/auth.json
+++ b/sk/auth.json
@@ -168,7 +168,9 @@
       "sms_button": "SMS",
       "email_button": "Email",
       "do_not_use_mfa_link": "Nepoužívať viacfaktorovú autentifikáciu",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Stratili ste svoje zariadenie?",
+      "lost_your_device_link": "Použite obnovovací kód"
     },
     "account_locked_page": {
       "page_title": "Účet zablokovaný | ${business_name}",

--- a/sv/auth.json
+++ b/sv/auth.json
@@ -169,7 +169,9 @@
       "sms_button": "SMS",
       "email_button": "Email",
       "do_not_use_mfa_link": "Använd inte MFA",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Har du tappat bort din enhet?",
+      "lost_your_device_link": "Använd en återställningskod"
     },
     "account_locked_page": {
       "page_title": "Kontot är låst | ${business_name}",

--- a/th/auth.json
+++ b/th/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "SMS",
       "email_button": "อีเมล",
       "do_not_use_mfa_link": "ไม่ใช้การยืนยันตัวตนหลายปัจจัย",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "ทำอุปกรณ์หายแล้วหรือยัง?",
+      "lost_your_device_link": "ใช้รหัสกู้คืน"
     },
     "account_locked_page": {
       "page_title": "บัญชีถูกล็อค | ${business_name}",

--- a/tr/auth.json
+++ b/tr/auth.json
@@ -154,7 +154,9 @@
       "sms_button": "SMS",
       "email_button": "E-posta",
       "do_not_use_mfa_link": "Çok faktörlü kimlik doğrulamayı kullanmayın",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Cihazınızı mı kaybettiniz?",
+      "lost_your_device_link": "Kurtarma kodunu kullanın"
     },
     "account_locked_page": {
       "page_title": "Hesap kilitlendi | ${business_name}",

--- a/uk/auth.json
+++ b/uk/auth.json
@@ -169,7 +169,9 @@
       "sms_button": "SMS",
       "email_button": "Електронна адреса",
       "do_not_use_mfa_link": "Не використовувати багатофакторну автентифікацію",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Втратили свій пристрій?",
+      "lost_your_device_link": "Використовуйте код відновлення"
     },
     "account_locked_page": {
       "page_title": "Обліковий запис заблоковано | ${business_name}",

--- a/vi/auth.json
+++ b/vi/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "SMS",
       "email_button": "Email",
       "do_not_use_mfa_link": "Không sử dụng xác thực đa lớp",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "Bạn bị mất thiết bị?",
+      "lost_your_device_link": "Sử dụng mã khôi phục"
     },
     "account_locked_page": {
       "page_title": "Tài khoản đã bị khóa | ${business_name}",

--- a/zh-Hans/auth.json
+++ b/zh-Hans/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "短信",
       "email_button": "邮箱",
       "do_not_use_mfa_link": "不要使用多重身份验证",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "设备丢失了吗？",
+      "lost_your_device_link": "使用恢复码"
     },
     "account_locked_page": {
       "page_title": "帐户被锁定 | ${business_name}",

--- a/zh-Hant/auth.json
+++ b/zh-Hant/auth.json
@@ -151,7 +151,9 @@
       "sms_button": "短信",
       "email_button": "電郵",
       "do_not_use_mfa_link": "不要使用多重身份驗證",
-      "translate_context": "Page to choose a preferred MFA method"
+      "translate_context": "Page to choose a preferred MFA method",
+      "lost_your_device_description": "遺失您的裝置了嗎？",
+      "lost_your_device_link": "使用恢復碼"
     },
     "account_locked_page": {
       "page_title": "帳户被鎖定 | ${business_name}",


### PR DESCRIPTION
## What

Adds two optional keys under `choose_mfa_method_page`:

- `lost_your_device_description` — "Lost your device?"
- `lost_your_device_link` — "Use a recovery code"

English values are added to `en`, `en-GB`, and `en-US`. `auth-schema.json` declares both properties as optional (`required` untouched), so locales without the keys stay valid and fall back to English at runtime via `get_context_translations`.

## Why

The MFA choose-method page in the main Kinde app currently hardcodes the recovery-code fallback strings in English. The app-side change reads these keys with a guarded English fallback; this PR must merge first so the submodule bump imports the new defaults.

## Notes

- The auto-translate workflow should populate the remaining locales; French must contain both keys before merge (an app-side regression test asserts the French rendering).
- Locales the workflow does not cover simply inherit English for these keys — safe, just not localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)